### PR TITLE
Feature/#10 search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ src/main/resources/application-local.yml
 src/main/resources/*.json
 .DS_Store
 dump.rdb
+
+# querydsl
+/build/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,16 @@ repositories {
 	mavenCentral()
 }
 
+def querydslOutputDir = layout.buildDirectory.dir("generated/querydsl")
+
+sourceSets {
+	main {
+		java {
+			srcDir querydslOutputDir
+		}
+	}
+}
+
 dependencies {
 	// 기본 기능
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -32,6 +42,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// Querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'

--- a/src/main/java/com/example/trendlog/controller/PostController.java
+++ b/src/main/java/com/example/trendlog/controller/PostController.java
@@ -1,7 +1,5 @@
 package com.example.trendlog.controller;
 
-import com.example.trendlog.domain.User;
-import com.example.trendlog.domain.post.PostSearchCondition;
 import com.example.trendlog.dto.request.post.PostCommentRequest;
 import com.example.trendlog.dto.request.post.PostCreateUpdateRequest;
 import com.example.trendlog.dto.response.post.PostPagedResponse;
@@ -11,12 +9,8 @@ import com.example.trendlog.global.docs.PostSwaggerSpec;
 import com.example.trendlog.global.dto.DataResponse;
 import com.example.trendlog.service.PostCommentService;
 import com.example.trendlog.service.PostService;
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -132,84 +126,6 @@ public class PostController implements PostSwaggerSpec {
         postCommentService.likePostComment(principal, postId, commentId);
         return ResponseEntity.ok(DataResponse.ok());
     }
-
-    // 게시글에서 게시글 이름, 게시글 내용, 게시글 태그, 장소 중에서 해당하는 거 검색
-    @GetMapping("/search")
-    public ResponseEntity<DataResponse<PostPagedResponse>> searchPosts(
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "all") String emotion,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "latest") String sortBy
-    ) {
-        PostSearchCondition condition = new PostSearchCondition();
-        condition.setKeyword(keyword);
-        condition.setEmotion(emotion);
-
-        Sort sort = switch (sortBy) {
-            case "trend" -> Sort.by(Sort.Direction.DESC, "trendScore"); // 커스텀 키
-            default -> Sort.by(Sort.Direction.DESC, "createdAt");
-        };
-
-        Pageable pageable = PageRequest.of(page-1, size, sort);
-        PostPagedResponse postPagedResponse = postService.searchAllPosts(condition, pageable);
-        return ResponseEntity.ok(DataResponse.from(postPagedResponse));
-    }
-
-    // 내 게시글 검색
-    @GetMapping("/search/my")
-    public ResponseEntity<DataResponse<PostPagedResponse>> searchMyPosts(
-            Principal principal,
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "all") String emotion,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "latest") String sortBy
-    ) {
-        User user = postService.findUser(principal);
-
-        PostSearchCondition condition = new PostSearchCondition();
-        condition.setKeyword(keyword);
-        condition.setEmotion(emotion);
-        condition.setUserId(user.getId());
-
-        Sort sort = switch (sortBy) {
-            case "trend" -> Sort.by(Sort.Direction.DESC, "trendScore"); // 커스텀 키
-            default -> Sort.by(Sort.Direction.DESC, "createdAt");
-        };
-
-        Pageable pageable = PageRequest.of(page-1, size, sort);
-        PostPagedResponse postPagedResponse = postService.searchMyPosts(condition, pageable);
-        return ResponseEntity.ok(DataResponse.from(postPagedResponse));
-    }
-
-    @GetMapping("/search/scrap")
-    public ResponseEntity<DataResponse<PostPagedResponse>> searchScrappedPosts(
-            Principal principal,
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "all") String emotion,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "latest") String sortBy
-    ) {
-        User user = postService.findUser(principal);
-
-        PostSearchCondition condition = new PostSearchCondition();
-        condition.setKeyword(keyword);
-        condition.setEmotion(emotion);
-        condition.setUserId(user.getId());
-
-        Sort sort = switch (sortBy) {
-            case "trend" -> Sort.by(Sort.Direction.DESC, "trendScore");
-            default -> Sort.by(Sort.Direction.DESC, "createdAt");
-        };
-
-        Pageable pageable = PageRequest.of(page - 1, size, sort);
-        PostPagedResponse postPagedResponse = postService.searchScrappedPosts(condition, pageable);
-        return ResponseEntity.ok(DataResponse.from(postPagedResponse));
-    }
-
-
 
 }
 

--- a/src/main/java/com/example/trendlog/controller/PostController.java
+++ b/src/main/java/com/example/trendlog/controller/PostController.java
@@ -183,6 +183,32 @@ public class PostController implements PostSwaggerSpec {
         return ResponseEntity.ok(DataResponse.from(postPagedResponse));
     }
 
+    @GetMapping("/search/scrap")
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchScrappedPosts(
+            Principal principal,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    ) {
+        User user = postService.findUser(principal);
+
+        PostSearchCondition condition = new PostSearchCondition();
+        condition.setKeyword(keyword);
+        condition.setEmotion(emotion);
+        condition.setUserId(user.getId());
+
+        Sort sort = switch (sortBy) {
+            case "trend" -> Sort.by(Sort.Direction.DESC, "trendScore");
+            default -> Sort.by(Sort.Direction.DESC, "createdAt");
+        };
+
+        Pageable pageable = PageRequest.of(page - 1, size, sort);
+        PostPagedResponse postPagedResponse = postService.searchScrappedPosts(condition, pageable);
+        return ResponseEntity.ok(DataResponse.from(postPagedResponse));
+    }
+
 
 
 }

--- a/src/main/java/com/example/trendlog/controller/SearchController.java
+++ b/src/main/java/com/example/trendlog/controller/SearchController.java
@@ -1,0 +1,107 @@
+package com.example.trendlog.controller;
+
+import com.example.trendlog.domain.User;
+import com.example.trendlog.domain.post.PostSearchCondition;
+import com.example.trendlog.dto.response.post.PostPagedResponse;
+import com.example.trendlog.global.docs.SearchSwaggerSpec;
+import com.example.trendlog.global.dto.DataResponse;
+import com.example.trendlog.service.PostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/search")
+@RequiredArgsConstructor
+public class SearchController implements SearchSwaggerSpec {
+
+    private final PostService postService;
+
+    // 게시글에서 게시글 이름, 게시글 내용, 게시글 태그, 장소 중에서 해당하는 거 검색
+    @GetMapping("/posts")
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchPosts(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    ) {
+        PostSearchCondition condition = new PostSearchCondition();
+        condition.setKeyword(keyword);
+        condition.setEmotion(emotion);
+
+        Sort sort = switch (sortBy) {
+            case "trend" -> Sort.by(Sort.Direction.DESC, "trendScore"); // 커스텀 키
+            default -> Sort.by(Sort.Direction.DESC, "createdAt");
+        };
+
+        Pageable pageable = PageRequest.of(page-1, size, sort);
+        PostPagedResponse postPagedResponse = postService.searchAllPosts(condition, pageable);
+        return ResponseEntity.ok(DataResponse.from(postPagedResponse));
+    }
+
+    // 내 게시글 검색
+    @GetMapping("/posts/my")
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchMyPosts(
+            Principal principal,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    ) {
+        User user = postService.findUser(principal);
+
+        PostSearchCondition condition = new PostSearchCondition();
+        condition.setKeyword(keyword);
+        condition.setEmotion(emotion);
+        condition.setUserId(user.getId());
+
+        Sort sort = switch (sortBy) {
+            case "trend" -> Sort.by(Sort.Direction.DESC, "trendScore"); // 커스텀 키
+            default -> Sort.by(Sort.Direction.DESC, "createdAt");
+        };
+
+        Pageable pageable = PageRequest.of(page-1, size, sort);
+        PostPagedResponse postPagedResponse = postService.searchMyPosts(condition, pageable);
+        return ResponseEntity.ok(DataResponse.from(postPagedResponse));
+    }
+
+    @GetMapping("/posts/scrap")
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchScrappedPosts(
+            Principal principal,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    ) {
+        User user = postService.findUser(principal);
+
+        PostSearchCondition condition = new PostSearchCondition();
+        condition.setKeyword(keyword);
+        condition.setEmotion(emotion);
+        condition.setUserId(user.getId());
+
+        Sort sort = switch (sortBy) {
+            case "trend" -> Sort.by(Sort.Direction.DESC, "trendScore");
+            default -> Sort.by(Sort.Direction.DESC, "createdAt");
+        };
+
+        Pageable pageable = PageRequest.of(page - 1, size, sort);
+        PostPagedResponse postPagedResponse = postService.searchScrappedPosts(condition, pageable);
+        return ResponseEntity.ok(DataResponse.from(postPagedResponse));
+    }
+
+
+}

--- a/src/main/java/com/example/trendlog/domain/post/Post.java
+++ b/src/main/java/com/example/trendlog/domain/post/Post.java
@@ -29,8 +29,6 @@ public class Post {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trend_id")
     private Trend trend;
-    @Lob
-    @Column(columnDefinition = "TEXT")
     private String description;
     private String location; // 위치명
     private Double latitude; // 위도

--- a/src/main/java/com/example/trendlog/domain/post/PostComment.java
+++ b/src/main/java/com/example/trendlog/domain/post/PostComment.java
@@ -21,8 +21,6 @@ public class PostComment {
     @Column(name = "post_comment_id")
     private Long id;
 
-    @Lob
-    @Column(columnDefinition = "TEXT")
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/trendlog/domain/post/PostSearchCondition.java
+++ b/src/main/java/com/example/trendlog/domain/post/PostSearchCondition.java
@@ -3,10 +3,13 @@ package com.example.trendlog.domain.post;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.UUID;
+
 @Getter
 @Setter
 public class PostSearchCondition {
     private String keyword;
     private String emotion;
+    private UUID userId;
 }
 

--- a/src/main/java/com/example/trendlog/domain/post/PostSearchCondition.java
+++ b/src/main/java/com/example/trendlog/domain/post/PostSearchCondition.java
@@ -1,0 +1,12 @@
+package com.example.trendlog.domain.post;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostSearchCondition {
+    private String keyword;
+    private String emotion;
+}
+

--- a/src/main/java/com/example/trendlog/domain/trend/TrendCategory.java
+++ b/src/main/java/com/example/trendlog/domain/trend/TrendCategory.java
@@ -1,12 +1,44 @@
 package com.example.trendlog.domain.trend;
 
+import com.example.trendlog.global.exception.AppException;
+import lombok.Getter;
+
+import static com.example.trendlog.global.exception.code.TrendErrorCode.INVALID_CATEGORY;
+
+//public enum TrendCategory {
+//    FOOD,         // 음식
+//    LIFESTYLE,    // 라이프스타일
+//    CULTURE,      // 문화
+//    HEALTH,       // 건강
+//    INVESTMENT,   // 투자
+//    SOCIAL,       // 소셜
+//    ETC           // 기타
+//    //더 추가하는게 좋을까요?
+//}
+
+@Getter
 public enum TrendCategory {
-    FOOD,         // 음식
-    LIFESTYLE,    // 라이프스타일
-    CULTURE,      // 문화
-    HEALTH,       // 건강
-    INVESTMENT,   // 투자
-    SOCIAL,       // 소셜
-    ETC           // 기타
-    //더 추가하는게 좋을까요?
+    FOOD("음식"),
+    LIFESTYLE("라이프스타일"),
+    CULTURE("문화"),
+    HEALTH("건강"),
+    INVESTMENT("투자"),
+    SOCIAL("사회"),
+    ETC("기타");
+
+    private final String description;
+
+    TrendCategory(String description) {
+        this.description = description;
+    }
+
+    public static TrendCategory from(String keyword) {
+        for (TrendCategory category : TrendCategory.values()) {
+            if (category.name().equalsIgnoreCase(keyword) || category.getDescription().equalsIgnoreCase(keyword)) {
+                return category;
+            }
+        }
+        throw new AppException(INVALID_CATEGORY);
+    }
 }
+

--- a/src/main/java/com/example/trendlog/domain/trend/TrendSearchCondition.java
+++ b/src/main/java/com/example/trendlog/domain/trend/TrendSearchCondition.java
@@ -1,0 +1,14 @@
+package com.example.trendlog.domain.trend;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class TrendSearchCondition {
+    private String keyword;
+    private String category;
+    private UUID userId;
+}

--- a/src/main/java/com/example/trendlog/dto/response/post/PostListResponse.java
+++ b/src/main/java/com/example/trendlog/dto/response/post/PostListResponse.java
@@ -32,4 +32,19 @@ public record PostListResponse(
                         .toList()
         );
     }
+
+    public static PostListResponse from(Post post, List<String> tags) {
+        String description = post.getDescription();
+        return new PostListResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getExperienceDate(),
+                post.getLocation(),
+                description != null ? (description.length()<30?description:description.substring(0,30)) : null,
+                post.getEmotion().name(),
+                post.getTrend().getTitle(), // 트렌드 이름
+                post.getTrend().getScore(),
+                tags
+        );
+    }
 }

--- a/src/main/java/com/example/trendlog/dto/response/trend/TrendSearchListResponse.java
+++ b/src/main/java/com/example/trendlog/dto/response/trend/TrendSearchListResponse.java
@@ -1,0 +1,17 @@
+package com.example.trendlog.dto.response.trend;
+
+import com.example.trendlog.domain.trend.Trend;
+
+public record TrendSearchListResponse(
+        Long id,
+        String title,
+        String category
+) {
+    public static TrendSearchListResponse from(Trend trend) {
+        return new TrendSearchListResponse(
+                trend.getId(),
+                trend.getTitle(),
+                trend.getCategory().name()
+        );
+    }
+}

--- a/src/main/java/com/example/trendlog/dto/response/trend/TrendSearchPagedResponse.java
+++ b/src/main/java/com/example/trendlog/dto/response/trend/TrendSearchPagedResponse.java
@@ -1,0 +1,24 @@
+package com.example.trendlog.dto.response.trend;
+
+import com.example.trendlog.domain.trend.Trend;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record TrendSearchPagedResponse(
+        List<TrendSearchListResponse> list,
+        int currentPage,
+        int pageSize,
+        long totalElements,
+        int totalPages
+) {
+    public static TrendSearchPagedResponse from(List<TrendSearchListResponse> list, Page<Trend> trends) {
+        return new TrendSearchPagedResponse(
+                list,
+                trends.getNumber(),
+                trends.getSize(),
+                trends.getTotalElements(),
+                trends.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/com/example/trendlog/global/config/QuerydslConfig.java
+++ b/src/main/java/com/example/trendlog/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.trendlog.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/example/trendlog/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/trendlog/global/config/SecurityConfig.java
@@ -50,6 +50,9 @@ public class SecurityConfig {
                                 HttpMethod.GET,
                                 "/api/v1/tags/popular").permitAll()
                         .requestMatchers(
+                                HttpMethod.GET,
+                                "api/v1/search/posts").permitAll()
+                        .requestMatchers(
                                 "/debug/scheduler/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/example/trendlog/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/trendlog/global/config/SecurityConfig.java
@@ -52,7 +52,8 @@ public class SecurityConfig {
                                 "/api/v1/tags/popular").permitAll()
                         .requestMatchers(
                                 HttpMethod.GET,
-                                "api/v1/search/posts").permitAll()
+                                "api/v1/search/posts",
+                                "api/v1/search/trends").permitAll()
                         .requestMatchers(
                                 "/debug/scheduler/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()

--- a/src/main/java/com/example/trendlog/global/docs/PostSwaggerSpec.java
+++ b/src/main/java/com/example/trendlog/global/docs/PostSwaggerSpec.java
@@ -194,4 +194,36 @@ public interface PostSwaggerSpec {
             @PathVariable Long postId,
             @PathVariable Long commentId
     );
+
+    // 게시글 검색
+    @Operation(summary = "게시글 검색", description = "키워드, 감정, 정렬(latest/trend) 조건으로 게시글을 검색합니다.\n " +
+            "현재 존재하는 감정은 JOY, EXCITEMENT, NOSTALGIA, SURPRISE, LOVE 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 검색 성공")
+    })
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchPosts(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    );
+
+    // 내 게시글 검색
+    @Operation(summary = "내 게시글 검색", description = "내가 작성한 게시글을 키워드, 감정, 정렬(latest/trend) 조건으로 검색합니다.\n " +
+            "현재 존재하는 감정은 JOY, EXCITEMENT, NOSTALGIA, SURPRISE, LOVE 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 게시글 검색 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자(USER-011)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchMyPosts(
+            Principal principal,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    );
 }

--- a/src/main/java/com/example/trendlog/global/docs/PostSwaggerSpec.java
+++ b/src/main/java/com/example/trendlog/global/docs/PostSwaggerSpec.java
@@ -226,4 +226,22 @@ public interface PostSwaggerSpec {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "latest") String sortBy
     );
+
+    // 내가 스크랩한 게시글 검색
+    @Operation(summary = "내가 스크랩한 게시글 검색", description = "내가 스크랩한 게시글을 키워드, 감정, 정렬(latest/trend) 조건으로 검색합니다.\n " +
+            "현재 존재하는 감정은 JOY, EXCITEMENT, NOSTALGIA, SURPRISE, LOVE 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내가 스크랩한 게시글 검색 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자(USER-011)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchScrappedPosts(
+            Principal principal,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    );
 }

--- a/src/main/java/com/example/trendlog/global/docs/PostSwaggerSpec.java
+++ b/src/main/java/com/example/trendlog/global/docs/PostSwaggerSpec.java
@@ -195,53 +195,5 @@ public interface PostSwaggerSpec {
             @PathVariable Long commentId
     );
 
-    // 게시글 검색
-    @Operation(summary = "게시글 검색", description = "키워드, 감정, 정렬(latest/trend) 조건으로 게시글을 검색합니다.\n " +
-            "현재 존재하는 감정은 JOY, EXCITEMENT, NOSTALGIA, SURPRISE, LOVE 입니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "게시글 검색 성공")
-    })
-    public ResponseEntity<DataResponse<PostPagedResponse>> searchPosts(
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "all") String emotion,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "latest") String sortBy
-    );
 
-    // 내 게시글 검색
-    @Operation(summary = "내 게시글 검색", description = "내가 작성한 게시글을 키워드, 감정, 정렬(latest/trend) 조건으로 검색합니다.\n " +
-            "현재 존재하는 감정은 JOY, EXCITEMENT, NOSTALGIA, SURPRISE, LOVE 입니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "내 게시글 검색 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자(USER-011)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @SecurityRequirement(name = "bearerAuth")
-    public ResponseEntity<DataResponse<PostPagedResponse>> searchMyPosts(
-            Principal principal,
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "all") String emotion,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "latest") String sortBy
-    );
-
-    // 내가 스크랩한 게시글 검색
-    @Operation(summary = "내가 스크랩한 게시글 검색", description = "내가 스크랩한 게시글을 키워드, 감정, 정렬(latest/trend) 조건으로 검색합니다.\n " +
-            "현재 존재하는 감정은 JOY, EXCITEMENT, NOSTALGIA, SURPRISE, LOVE 입니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "내가 스크랩한 게시글 검색 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자(USER-011)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @SecurityRequirement(name = "bearerAuth")
-    public ResponseEntity<DataResponse<PostPagedResponse>> searchScrappedPosts(
-            Principal principal,
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "all") String emotion,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "latest") String sortBy
-    );
 }

--- a/src/main/java/com/example/trendlog/global/docs/SearchSwaggerSpec.java
+++ b/src/main/java/com/example/trendlog/global/docs/SearchSwaggerSpec.java
@@ -1,6 +1,7 @@
 package com.example.trendlog.global.docs;
 
 import com.example.trendlog.dto.response.post.PostPagedResponse;
+import com.example.trendlog.dto.response.trend.TrendSearchPagedResponse;
 import com.example.trendlog.global.dto.DataResponse;
 import com.example.trendlog.global.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -66,4 +67,37 @@ public interface SearchSwaggerSpec {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "latest") String sortBy
     );
+
+    // 트렌드 검색
+    @Operation(summary = "트렌드 검색", description = "트렌드를 키워드, 카테고리, 정렬(latest/trend) 조건으로 검색합니다.\n " +
+            "현재 존재하는 카테고리는 FOOD, LIFESTYLE, CULTURE, HEALTH, INVESTMENT, SOCIAL, ETC입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "트렌드 검색 성공")
+    })
+    public ResponseEntity<DataResponse<TrendSearchPagedResponse>> searchTrends(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String category,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy // trend, latest
+    );
+
+    // 내가 스크랩한 트렌드 검색
+    @Operation(summary = "내가 스크랩한 트렌드 검색", description = "내가 스크랩한 트렌드를 키워드, 카테고리, 정렬(latest/trend) 조건으로 검색합니다.\n " +
+            "현재 존재하는 카테고리는 FOOD, LIFESTYLE, CULTURE, HEALTH, INVESTMENT, SOCIAL, ETC입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내가 스크랩한 트렌드 검색 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자(USER-011)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<DataResponse<TrendSearchPagedResponse>> searchScrappedTrends(
+            Principal principal,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String category,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy // trend, latest
+    );
+
 }

--- a/src/main/java/com/example/trendlog/global/docs/SearchSwaggerSpec.java
+++ b/src/main/java/com/example/trendlog/global/docs/SearchSwaggerSpec.java
@@ -1,0 +1,69 @@
+package com.example.trendlog.global.docs;
+
+import com.example.trendlog.dto.response.post.PostPagedResponse;
+import com.example.trendlog.global.dto.DataResponse;
+import com.example.trendlog.global.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.security.Principal;
+
+@Tag(name = "Search", description = "검색 관련 API")
+public interface SearchSwaggerSpec {
+    // 게시글 검색
+    @Operation(summary = "게시글 검색", description = "키워드, 감정, 정렬(latest/trend) 조건으로 게시글을 검색합니다.\n " +
+            "현재 존재하는 감정은 JOY, EXCITEMENT, NOSTALGIA, SURPRISE, LOVE 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 검색 성공")
+    })
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchPosts(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    );
+
+    // 내 게시글 검색
+    @Operation(summary = "내 게시글 검색", description = "내가 작성한 게시글을 키워드, 감정, 정렬(latest/trend) 조건으로 검색합니다.\n " +
+            "현재 존재하는 감정은 JOY, EXCITEMENT, NOSTALGIA, SURPRISE, LOVE 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 게시글 검색 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자(USER-011)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchMyPosts(
+            Principal principal,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    );
+
+    // 내가 스크랩한 게시글 검색
+    @Operation(summary = "내가 스크랩한 게시글 검색", description = "내가 스크랩한 게시글을 키워드, 감정, 정렬(latest/trend) 조건으로 검색합니다.\n " +
+            "현재 존재하는 감정은 JOY, EXCITEMENT, NOSTALGIA, SURPRISE, LOVE 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내가 스크랩한 게시글 검색 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자(USER-011)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<DataResponse<PostPagedResponse>> searchScrappedPosts(
+            Principal principal,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String emotion,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy
+    );
+}

--- a/src/main/java/com/example/trendlog/repository/post/PostRepository.java
+++ b/src/main/java/com/example/trendlog/repository/post/PostRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
     // 삭제되지 않은 게시글을 최신순으로 조회
     Page<Post> findAllByDeletedFalseOrderByCreatedAtDesc(Pageable pageable);

--- a/src/main/java/com/example/trendlog/repository/post/PostRepositoryCustom.java
+++ b/src/main/java/com/example/trendlog/repository/post/PostRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.trendlog.repository.post;
+
+import com.example.trendlog.domain.post.Post;
+import com.example.trendlog.domain.post.PostSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryCustom {
+    public Page<Post> searchAll(PostSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/com/example/trendlog/repository/post/PostRepositoryCustom.java
+++ b/src/main/java/com/example/trendlog/repository/post/PostRepositoryCustom.java
@@ -6,5 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostRepositoryCustom {
-    public Page<Post> searchAll(PostSearchCondition condition, Pageable pageable);
+    Page<Post> searchAll(PostSearchCondition condition, Pageable pageable);
+
+    Page<Post> searchMy(PostSearchCondition condition, Pageable pageable);
+
 }

--- a/src/main/java/com/example/trendlog/repository/post/PostRepositoryCustom.java
+++ b/src/main/java/com/example/trendlog/repository/post/PostRepositoryCustom.java
@@ -10,4 +10,6 @@ public interface PostRepositoryCustom {
 
     Page<Post> searchMy(PostSearchCondition condition, Pageable pageable);
 
+    Page<Post> searchScrapped(PostSearchCondition condition, Pageable pageable);
+
 }

--- a/src/main/java/com/example/trendlog/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/com/example/trendlog/repository/post/PostRepositoryImpl.java
@@ -1,0 +1,95 @@
+package com.example.trendlog.repository.post;
+
+import com.example.trendlog.domain.post.*;
+import com.example.trendlog.domain.trend.QTrend;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Post> searchAll(PostSearchCondition condition, Pageable pageable) {
+        QPost post = QPost.post;
+        QTrend trend = QTrend.trend;
+        QPostTag postTag = QPostTag.postTag;
+        QTag tag = QTag.tag;
+
+        // 1. Post만 검색 (태그 조건은 필터로만 사용)
+        List<Post> content = queryFactory
+                .selectFrom(post)
+                .leftJoin(post.trend, trend).fetchJoin()
+                .leftJoin(post.tags, postTag)
+                .leftJoin(postTag.tag, tag)
+                .where(
+                        keywordMatch(condition.getKeyword(), post, tag),
+                        emotionMatch(condition.getEmotion(), post)
+                )
+                .orderBy(getSortOrder(pageable, post, trend))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .distinct()
+                .fetch();
+
+
+        // 2. 전체 개수 카운트
+        Long total = queryFactory
+                .select(post.countDistinct())
+                .from(post)
+                .leftJoin(post.trend, trend)
+                .leftJoin(post.tags, postTag)
+                .leftJoin(postTag.tag, tag)
+                .where(
+                        keywordMatch(condition.getKeyword(), post, tag),
+                        emotionMatch(condition.getEmotion(), post)
+                )
+                .fetchOne();
+        long safeTotal = total != null ? total : 0L;
+
+        return new PageImpl<>(content, pageable, safeTotal);
+    }
+
+
+
+    // 키워드 검색 조건: 제목, 내용, 장소
+    private BooleanExpression keywordMatch(String keyword, QPost post, QTag tag) {
+        if (!StringUtils.hasText(keyword)) return null;
+
+        return post.title.containsIgnoreCase(keyword)
+                .or(post.description.containsIgnoreCase(keyword))
+                .or(post.location.containsIgnoreCase(keyword))
+                .or(tag.name.containsIgnoreCase(keyword));
+    }
+
+    // 감정 필터
+    private BooleanExpression emotionMatch(String emotion, QPost post) {
+        if (!StringUtils.hasText(emotion) || emotion.equals("전체")) return null;
+        return post.emotion.stringValue().eq(emotion);
+    }
+
+    // 정렬 조건 (latest, trend)
+    private OrderSpecifier<?> getSortOrder(Pageable pageable, QPost post, QTrend trend) {
+        for (Sort.Order order : pageable.getSort()) {
+            String property = order.getProperty();
+            boolean asc = order.isAscending();
+
+            return switch (property) {
+                case "createdAt" -> asc ? post.createdAt.asc() : post.createdAt.desc();
+                case "trendScore" -> asc ? trend.score.asc() : trend.score.desc();
+                default -> post.createdAt.desc();
+            };
+        }
+        return post.createdAt.desc();
+    }
+}

--- a/src/main/java/com/example/trendlog/repository/trend/TrendRepository.java
+++ b/src/main/java/com/example/trendlog/repository/trend/TrendRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface TrendRepository extends JpaRepository<Trend, Long> {
+public interface TrendRepository extends JpaRepository<Trend, Long>, TrendRepositoryCustom {
     // 최근 일주일 내에 생성된 트렌드 중 상위 점수순 정렬 (popular)
     List<Trend> findTop5ByCreatedAtAfterOrderByScoreDesc(java.time.LocalDateTime after);
 

--- a/src/main/java/com/example/trendlog/repository/trend/TrendRepositoryCustom.java
+++ b/src/main/java/com/example/trendlog/repository/trend/TrendRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.example.trendlog.repository.trend;
+
+import com.example.trendlog.domain.trend.Trend;
+import com.example.trendlog.domain.trend.TrendSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface TrendRepositoryCustom {
+    Page<Trend> searchAll(TrendSearchCondition condition, Pageable pageable);
+    Page<Trend> searchScrapped(TrendSearchCondition condition, Pageable pageable);
+
+}

--- a/src/main/java/com/example/trendlog/repository/trend/TrendRepositoryImpl.java
+++ b/src/main/java/com/example/trendlog/repository/trend/TrendRepositoryImpl.java
@@ -1,0 +1,123 @@
+package com.example.trendlog.repository.trend;
+
+import com.example.trendlog.domain.trend.*;
+import com.example.trendlog.global.exception.AppException;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class TrendRepositoryImpl implements TrendRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Trend> searchAll(TrendSearchCondition condition, Pageable pageable) {
+        QTrend trend = QTrend.trend;
+
+        List<Trend> content = queryFactory
+                .selectFrom(trend)
+                .where(
+                        titleOrCategoryMatch(condition.getKeyword(), trend),
+                        categoryEquals(condition.getCategory(), trend)
+                )
+                .orderBy(getSortOrder(pageable, trend))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(trend.count())
+                .from(trend)
+                .where(
+                        titleOrCategoryMatch(condition.getKeyword(), trend),
+                        categoryEquals(condition.getCategory(), trend)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    public Page<Trend> searchScrapped(TrendSearchCondition condition, Pageable pageable) {
+        QTrend trend = QTrend.trend;
+        QTrendScrap scrap = QTrendScrap.trendScrap;
+
+        List<Trend> content = queryFactory
+                .selectFrom(trend)
+                .join(scrap).on(scrap.trend.eq(trend))
+                .where(
+                        scrap.user.id.eq(condition.getUserId()),
+                        titleOrCategoryMatch(condition.getKeyword(), trend),
+                        categoryEquals(condition.getCategory(), trend)
+                )
+                .orderBy(getSortOrder(pageable, trend))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(trend.count())
+                .from(trend)
+                .join(scrap).on(scrap.trend.eq(trend))
+                .where(
+                        scrap.user.id.eq(condition.getUserId()),
+                        titleOrCategoryMatch(condition.getKeyword(), trend),
+                        categoryEquals(condition.getCategory(), trend)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+
+    // 키워드 검색 조건: 제목, 카테고리명
+    private BooleanExpression titleOrCategoryMatch(String keyword, QTrend trend) {
+        if (!StringUtils.hasText(keyword)) return null;
+
+        BooleanExpression titleMatch = trend.title.containsIgnoreCase(keyword);
+
+        BooleanExpression categoryMatch = null;
+        try {
+            TrendCategory matchedCategory = TrendCategory.from(keyword);
+            categoryMatch = trend.category.eq(matchedCategory);
+        } catch (AppException ignored) {
+            return titleMatch; // 카테고리 매칭 실패 시 제목만으로 검색
+        }
+
+        return categoryMatch != null ? titleMatch.or(categoryMatch) : titleMatch;
+    }
+
+
+    private BooleanExpression categoryEquals(String category, QTrend trend) {
+        if (!StringUtils.hasText(category) || category.equals("all")) return null;
+        return trend.category.stringValue().eq(category);
+    }
+
+    private OrderSpecifier<?>[] getSortOrder(Pageable pageable, QTrend trend) {
+        for (Sort.Order order : pageable.getSort()) {
+            String property = order.getProperty();
+            boolean asc = order.isAscending();
+
+            return switch (property) {
+                case "createdAt" -> new OrderSpecifier[]{
+                        asc ? trend.createdAt.asc() : trend.createdAt.desc()
+                };
+                case "trendScore" -> new OrderSpecifier[]{
+                        asc ? trend.score.asc() : trend.score.desc(),
+                        trend.createdAt.desc() // 같은 점수면 최신순
+                };
+                default -> new OrderSpecifier[]{trend.createdAt.desc()};
+            };
+        }
+        return new OrderSpecifier[]{trend.createdAt.desc()};
+    }
+}
+

--- a/src/main/java/com/example/trendlog/service/TrendService.java
+++ b/src/main/java/com/example/trendlog/service/TrendService.java
@@ -23,10 +23,13 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+
+import static com.example.trendlog.global.exception.code.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -309,4 +312,31 @@ public class TrendService {
                 searchCount
         );
     }
+
+    /**
+     * 트렌드 검색
+     */
+    public TrendSearchPagedResponse searchTrends(TrendSearchCondition condition, Pageable pageable) {
+        Page<Trend> trends = trendRepository.searchAll(condition, pageable);
+
+        List<TrendSearchListResponse> responseList = trends.getContent().stream()
+                .map(TrendSearchListResponse::from)
+                .toList();
+
+        return TrendSearchPagedResponse.from(responseList, trends);
+    }
+
+    /**
+     * 스크랩된 트렌드 검색
+     */
+    public TrendSearchPagedResponse searchScrappedTrends(TrendSearchCondition condition, Pageable pageable) {
+        Page<Trend> trends = trendRepository.searchScrapped(condition, pageable);
+
+        List<TrendSearchListResponse> responseList = trends.getContent().stream()
+                .map(TrendSearchListResponse::from)
+                .toList();
+
+        return TrendSearchPagedResponse.from(responseList, trends);
+    }
+
 }

--- a/src/main/java/com/example/trendlog/service/UserService.java
+++ b/src/main/java/com/example/trendlog/service/UserService.java
@@ -17,6 +17,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.security.Principal;
 import java.util.UUID;
 
+import static com.example.trendlog.global.exception.code.UserErrorCode.USER_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -109,5 +111,11 @@ public class UserService {
         UUID userId = getUserByEmail(principal.getName()).getId();
         return gcsService.uploadToTemp(file, userId);
     }
+
+    public User findUser(Principal principal) {
+        return userRepository.findByEmail(principal.getName())
+                .orElseThrow(() -> new AppException(USER_NOT_FOUND));
+    }
+
 
 }


### PR DESCRIPTION
## #️⃣ Issue Number
#10

## 📝 요약(Summary)
- (게시글) 게시글, 태그, 내 게시글 검색 기능 구현
- (트렌드) 트렌드, 카테고리 검색 기능 구현
- (마이페이지) 내가 스크랩한 게시글, 내가 스크랩한 트렌드 검색 기능 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
- 마이페이지에서 나의 스크랩에서 상단에 검색 기능이 있는게 아니라 반환하는 형식이 다르기 때문에 탭(게시글/트렌드)을 선택하고 그 위에 검색 기능이 생기게 해야할 것 같습니다.
- 트렌드 검색 결과 : 트렌드 id, 트렌드 제목, 트렌드 카테고리
- 트렌드 카테고리에 한국어 설명 추가해놨습니다.
- 실행 전에 querydsl 설정을 해야하기 때문에 노션에 querydsl 부분 적어놨습니다.